### PR TITLE
correct moa typo on README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ ___
 // Introduced in vue file
 import FunctionalCalendar from 'vue-functional-calendar';
 Vue.use(FunctionalCalendar, {
-    dayNames: ['Moa', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']
+    dayNames: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']
 });
 ````
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "type": "git",
     "url": "https://github.com/ManukMinasyan/vue-functional-calendar.git"
   },
-  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "keywords": [
     "vue",
     "calendar",


### PR DESCRIPTION
Corrects the typo error 'Moa' to 'Mo'