### PR TITLE
correct typo

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,11 +1,13 @@
-import Vue from 'vue';
-import FunctionalCalendar from '../index';
-import Demo from './Demo';
-Vue.use(FunctionalCalendar, {dayNames: ['Moa', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']});
+import Vue from "vue";
+import FunctionalCalendar from "../index";
+import Demo from "./Demo";
+Vue.use(FunctionalCalendar, {
+  dayNames: ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
+});
 Vue.config.productionTip = false;
 
 new Vue({
-    el: '#app',
-    template: '<Demo/>',
-    components: {Demo}
+  el: "#app",
+  template: "<Demo/>",
+  components: { Demo }
 });


### PR DESCRIPTION
Corrects the typo error 'Moa' to 'Mo' in README