### PR TITLE
feat: add alwaysUseDefaultClasses prop for day slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ ___
 | arrowsPosition                   | String         | space-between | left, right, space-between |  Set arrows position               |
 | isDark                   | Boolean         | false       | true        | Dark theme                    |
 | isLayoutExpandable | Boolean | false | true | Enable expanding the calendar layout | 
+| alwaysUseDefaultClasses | Boolean | false | true | Always add default classes to Day element, even when overriding with a slot |
 ___
 
 ### Slots

--- a/src/components/Day.vue
+++ b/src/components/Day.vue
@@ -51,6 +51,10 @@ export default {
     calendar: {
       type: Object,
       required: true
+    },
+    alwaysUseDefaultClasses: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -272,7 +276,7 @@ export default {
     getClassNames(day) {
       let classes = []
 
-      if (!this.hasSlot('default')) {
+      if (!this.hasSlot('default') || this.alwaysUseDefaultClasses) {
         classes.push('vfc-span-day')
       }
 

--- a/src/components/FunctionalCalendar.vue
+++ b/src/components/FunctionalCalendar.vue
@@ -162,6 +162,7 @@
                       :week="week"
                       :day_key="day_key"
                       @dayMouseOver="dayMouseOver"
+                      :alwaysUseDefaultClasses="alwaysUseDefaultClasses"
                     >
                       <template v-slot:default="props">
                         <slot :week="props.week" :day="props.day"></slot>

--- a/src/mixins/propsAndData.js
+++ b/src/mixins/propsAndData.js
@@ -161,6 +161,10 @@ export const propsAndData = {
     arrowsPosition: {
       type: String,
       default: 'space-between'
+    },
+    alwaysUseDefaultClasses: {
+      type: Boolean,
+      default: false
     }
   },
   data() {


### PR DESCRIPTION
Add alwaysUseDefaultClasses prop for day slot, so it doesn't prevent the default class from being added when overriding the slot.