### PR TITLE
Move css declaration

### DIFF
--- a/src/components/FunctionalCalendar.vue
+++ b/src/components/FunctionalCalendar.vue
@@ -1705,11 +1705,11 @@ export default {
     border: none;
     padding: 5px;
     &.active {
+      background-color: #66b3cc;
       &:hover {
         background-color: #4f8a9e;
         cursor: pointer;
       }
-      background-color: #66b3cc;
     }
     &.disabled {
       background-color: rgb(148, 148, 148);


### PR DESCRIPTION
This fixes a Sass warning i'm seeing when building my Nuxt 3 project:

> Deprecation Warning: Sass's behavior for declarations that appear after nested rules will be changing to match the behavior specified by CSS in an upcoming version. To keep the existing behavior, move the declaration above the nested rule. To opt into the new behavior, wrap the declaration in `& {}`.

> More info: https://sass-lang.com/d/mixed-decls